### PR TITLE
fix(users): add pagination parameters

### DIFF
--- a/backend/app/Controllers/Http/UserController.js
+++ b/backend/app/Controllers/Http/UserController.js
@@ -44,7 +44,7 @@ class UserController {
    * @param {Request} ctx.request
    */
   async index ({ request, auth }) {
-    const { s, progress } = request.get();
+    const { s, progress, page, limit } = request.get();
 
     const query = User.query()
 
@@ -53,7 +53,7 @@ class UserController {
       query.where('name', 'like', searchTerm)
     }
 
-    const users = await query.fetch()
+    const users = await query.paginate(page || 1, limit || 25)
 
     if (!progress || !users.rows.length) {
       return users


### PR DESCRIPTION
Adiciona suporte a paginação no endpoint `/users` no backend
page (qual a pagina solicitada) - Default 1
limit (quantidade por página) - Default 25